### PR TITLE
feat: standalone parameters, corrected scale math, pointer events, and first tests

### DIFF
--- a/.github/workflows/cd.publish-automatic.yml
+++ b/.github/workflows/cd.publish-automatic.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   on-success:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     permissions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbx-audio/nectar",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Collection of JUCE-y modules for building web-based plugin GUIs 🧃",
     "private": false,
     "license": "MIT",
@@ -39,7 +39,8 @@
         "lint:fix": "eslint --cache --fix \"**/*.{ts,js}\"",
         "pre-commit": "lint-staged",
         "prepare": "husky install",
-        "prepublishOnly": "yarn build"
+        "prepublishOnly": "yarn build",
+        "test": "vitest run"
     },
     "devDependencies": {
         "@eslint/js": "9.33.0",
@@ -47,6 +48,7 @@
         "globals": "16.3.0",
         "husky": "8.0.3",
         "jiti": "2.5.1",
+        "jsdom": "26.1.0",
         "lint-staged": "16.1.5",
         "prettier": "3.6.2",
         "rimraf": "6.0.1",

--- a/src/event/event.classes.test.ts
+++ b/src/event/event.classes.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+
+/**
+ * jsdom does not implement PointerEvent, so the tests synthesize one on top of
+ * MouseEvent with the fields the manager relies on.
+ */
+class FakePointerEvent extends MouseEvent {
+    pointerId: number
+    pointerType: string
+
+    constructor(type: string, init: PointerEventInit = {}) {
+        super(type, init)
+        this.pointerId = init.pointerId ?? 0
+        this.pointerType = init.pointerType ?? 'mouse'
+    }
+}
+
+Object.defineProperty(window, 'PointerEvent', { value: FakePointerEvent })
+
+const addEventListenerSpy = vi.spyOn(document, 'addEventListener')
+const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
+
+const { GlobalEventManager } = await import('./event.classes.ts')
+
+function pressKey(key: string, init: KeyboardEventInit = {}, node: EventTarget = document): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init })
+    node.dispatchEvent(event)
+    return event
+}
+
+function releaseKey(key: string, node: EventTarget = document): KeyboardEvent {
+    const event = new KeyboardEvent('keyup', { key, bubbles: true, cancelable: true })
+    node.dispatchEvent(event)
+    return event
+}
+
+const CONSTRUCTOR_EVENTS = ['keydown', 'keyup', 'pointerdown']
+
+describe('GlobalEventManager listener efficiency', () => {
+    it('keeps exactly three document listeners regardless of subscription count', () => {
+        const unsubscribers: (() => void)[] = []
+        for (let i = 0; i < 10; i++) {
+            unsubscribers.push(GlobalEventManager.subscribeToKey(`Key${i}`, () => {}))
+            unsubscribers.push(GlobalEventManager.subscribeToPointerDown(() => {}))
+        }
+
+        const constructorRegistrations = addEventListenerSpy.mock.calls.filter(([type]) =>
+            CONSTRUCTOR_EVENTS.includes(type as string)
+        )
+        expect(constructorRegistrations).toHaveLength(3)
+
+        unsubscribers.forEach((unsubscribe) => unsubscribe())
+    })
+})
+
+describe('GlobalEventManager key subscriptions', () => {
+    it('scopes subscriptions to a target element', () => {
+        const inside = document.createElement('div')
+        const outside = document.createElement('div')
+        document.body.append(inside, outside)
+
+        const callback = vi.fn()
+        const unsubscribe = GlobalEventManager.subscribeToKey('s', callback, { target: inside })
+
+        pressKey('s', {}, outside)
+        expect(callback).not.toHaveBeenCalled()
+        releaseKey('s', outside)
+
+        pressKey('s', {}, inside)
+        expect(callback).toHaveBeenCalledTimes(1)
+
+        releaseKey('s', inside)
+        unsubscribe()
+        inside.remove()
+        outside.remove()
+    })
+
+    it('honours a scoped target through the focused element', () => {
+        const container = document.createElement('div')
+        const input = document.createElement('input')
+        container.appendChild(input)
+        document.body.appendChild(container)
+        input.focus()
+
+        const callback = vi.fn()
+        const unsubscribe = GlobalEventManager.subscribeToKey('f', callback, { target: container })
+
+        pressKey('f', {}, document)
+        expect(callback).toHaveBeenCalledTimes(1)
+
+        releaseKey('f')
+        unsubscribe()
+        container.remove()
+    })
+
+    it('calls preventDefault only when a callback reports the event as handled', () => {
+        const handledUnsubscribe = GlobalEventManager.subscribeToKey('p', () => true)
+        const handledEvent = pressKey('p')
+        expect(handledEvent.defaultPrevented).toBe(true)
+        releaseKey('p')
+        handledUnsubscribe()
+
+        const passiveUnsubscribe = GlobalEventManager.subscribeToKey('q', () => {})
+        const passiveEvent = pressKey('q')
+        expect(passiveEvent.defaultPrevented).toBe(false)
+        releaseKey('q')
+        passiveUnsubscribe()
+    })
+
+    it('fires held keys only for subscribers that opted into repeat', () => {
+        const single = vi.fn()
+        const repeating = vi.fn()
+        const unsubscribeSingle = GlobalEventManager.subscribeToKey('r', single)
+        const unsubscribeRepeating = GlobalEventManager.subscribeToKey('r', repeating, { repeat: true })
+
+        pressKey('r')
+        pressKey('r', { repeat: true })
+        pressKey('r', { repeat: true })
+        releaseKey('r')
+
+        expect(single).toHaveBeenCalledTimes(2)
+        expect(repeating).toHaveBeenCalledTimes(4)
+
+        unsubscribeSingle()
+        unsubscribeRepeating()
+    })
+
+    it('keeps the pressed state of a held key when its last subscriber leaves', () => {
+        const unsubscribe = GlobalEventManager.subscribeToKey('Shift', () => {})
+
+        pressKey('Shift')
+        unsubscribe()
+
+        expect(GlobalEventManager.isShiftPressed()).toBe(true)
+
+        releaseKey('Shift')
+        expect(GlobalEventManager.isShiftPressed()).toBe(false)
+    })
+})
+
+describe('GlobalEventManager pointer subscriptions', () => {
+    it('notifies pointer-down subscribers and supports the deprecated click alias', () => {
+        const pointerCallback = vi.fn()
+        const clickCallback = vi.fn()
+        const unsubscribePointer = GlobalEventManager.subscribeToPointerDown(pointerCallback)
+        const unsubscribeClick = GlobalEventManager.subscribeToClick(clickCallback)
+
+        document.dispatchEvent(new FakePointerEvent('pointerdown', { pointerId: 1, bubbles: true }))
+
+        expect(pointerCallback).toHaveBeenCalledTimes(1)
+        expect(clickCallback).toHaveBeenCalledTimes(1)
+
+        unsubscribePointer()
+        unsubscribeClick()
+    })
+})
+
+describe('GlobalEventManager drag hosting', () => {
+    function dispatchPointer(type: string, pointerId: number): void {
+        document.dispatchEvent(new FakePointerEvent(type, { pointerId, bubbles: true }))
+    }
+
+    it('routes moves for the dragging pointer only and ends on pointer up', () => {
+        const onMove = vi.fn()
+        const onEnd = vi.fn()
+
+        GlobalEventManager.beginDrag(new FakePointerEvent('pointerdown', { pointerId: 7 }), { onMove, onEnd })
+
+        dispatchPointer('pointermove', 7)
+        dispatchPointer('pointermove', 9)
+        expect(onMove).toHaveBeenCalledTimes(1)
+
+        dispatchPointer('pointerup', 7)
+        expect(onEnd).toHaveBeenCalledTimes(1)
+
+        dispatchPointer('pointermove', 7)
+        expect(onMove).toHaveBeenCalledTimes(1)
+    })
+
+    it('removes its document listeners on pointer up', () => {
+        removeEventListenerSpy.mockClear()
+
+        GlobalEventManager.beginDrag(new FakePointerEvent('pointerdown', { pointerId: 3 }), { onMove: vi.fn() })
+        dispatchPointer('pointerup', 3)
+
+        const removedTypes = removeEventListenerSpy.mock.calls.map(([type]) => type)
+        expect(removedTypes).toContain('pointermove')
+        expect(removedTypes).toContain('pointerup')
+        expect(removedTypes).toContain('pointercancel')
+    })
+
+    /**
+     * A leak here would be permanent: cancellation is the path taken when the OS
+     * steals the pointer (scrolling, alerts, palm rejection), not user release.
+     */
+    it('removes its document listeners on pointer cancel', () => {
+        const onMove = vi.fn()
+        const onEnd = vi.fn()
+        removeEventListenerSpy.mockClear()
+
+        GlobalEventManager.beginDrag(new FakePointerEvent('pointerdown', { pointerId: 4 }), { onMove, onEnd })
+        dispatchPointer('pointercancel', 4)
+
+        expect(onEnd).toHaveBeenCalledTimes(1)
+        const removedTypes = removeEventListenerSpy.mock.calls.map(([type]) => type)
+        expect(removedTypes).toContain('pointermove')
+        expect(removedTypes).toContain('pointerup')
+        expect(removedTypes).toContain('pointercancel')
+
+        dispatchPointer('pointermove', 4)
+        expect(onMove).not.toHaveBeenCalled()
+    })
+
+    it('ends the previous drag when a new one begins', () => {
+        const firstEnd = vi.fn()
+        const secondMove = vi.fn()
+
+        GlobalEventManager.beginDrag(new FakePointerEvent('pointerdown', { pointerId: 5 }), {
+            onMove: vi.fn(),
+            onEnd: firstEnd,
+        })
+        GlobalEventManager.beginDrag(new FakePointerEvent('pointerdown', { pointerId: 6 }), { onMove: secondMove })
+
+        expect(firstEnd).toHaveBeenCalledTimes(1)
+
+        dispatchPointer('pointermove', 6)
+        expect(secondMove).toHaveBeenCalledTimes(1)
+
+        dispatchPointer('pointerup', 6)
+    })
+})

--- a/src/event/event.classes.ts
+++ b/src/event/event.classes.ts
@@ -1,11 +1,26 @@
-import type { IGlobalEventManager } from './event.types'
+import type { IDragHandlers, IGlobalEventManager, IKeySubscriptionOptions, KeyEventCallback } from './event.types'
+
+interface IKeySubscription {
+    callback: KeyEventCallback
+    target?: HTMLElement
+    repeat: boolean
+}
+
+interface IActiveDrag {
+    pointerId: number
+    target: Element | null
+    onMove: (event: PointerEvent) => void
+    onFinish: (event: PointerEvent) => void
+    onEnd?: (event: PointerEvent) => void
+}
 
 class GlobalEventManagerImpl implements IGlobalEventManager {
     private static _instance: GlobalEventManagerImpl
 
     private _pressedKeys = new Map<string, boolean>()
-    private _keyCallbacks = new Map<string, Set<(pressed: boolean, event: KeyboardEvent) => void>>()
-    private _clickCallbacks = new Set<(event: MouseEvent) => void>()
+    private _keySubscriptions = new Map<string, Set<IKeySubscription>>()
+    private _pointerDownCallbacks = new Set<(event: PointerEvent) => void>()
+    private _activeDrag: IActiveDrag | null = null
 
     static getInstance(): IGlobalEventManager {
         if (!this._instance) {
@@ -17,18 +32,17 @@ class GlobalEventManagerImpl implements IGlobalEventManager {
     private constructor() {
         document.addEventListener('keydown', this.onKeyDown)
         document.addEventListener('keyup', this.onKeyUp)
-        document.addEventListener('mousedown', this.onMouseDown)
+        document.addEventListener('pointerdown', this.onPointerDown)
     }
 
     private onKeyDown = (event: KeyboardEvent) => {
         const key = event.key
-        const wasPressed = this._pressedKeys.get(key) ?? false
-        if (!wasPressed) {
-            this._pressedKeys.set(key, true)
-            const callbacks = this._keyCallbacks.get(key)
-            if (callbacks) {
-                callbacks.forEach((callback) => callback(true, event))
-            }
+        const isRepeat = event.repeat || (this._pressedKeys.get(key) ?? false)
+        this._pressedKeys.set(key, true)
+
+        const subscriptions = this._keySubscriptions.get(key)
+        if (subscriptions) {
+            this.dispatchKeyEvent(subscriptions, true, event, isRepeat)
         }
     }
 
@@ -37,37 +51,142 @@ class GlobalEventManagerImpl implements IGlobalEventManager {
         const wasPressed = this._pressedKeys.get(key) ?? false
         if (wasPressed) {
             this._pressedKeys.set(key, false)
-            const callbacks = this._keyCallbacks.get(key)
-            if (callbacks) {
-                callbacks.forEach((callback) => callback(false, event))
+            const subscriptions = this._keySubscriptions.get(key)
+            if (subscriptions) {
+                this.dispatchKeyEvent(subscriptions, false, event, false)
             }
         }
     }
 
-    private onMouseDown = (event: MouseEvent) => {
-        this._clickCallbacks.forEach((callback) => callback(event))
+    private dispatchKeyEvent(
+        subscriptions: Set<IKeySubscription>,
+        pressed: boolean,
+        event: KeyboardEvent,
+        isRepeat: boolean
+    ): void {
+        let handled = false
+        subscriptions.forEach((subscription) => {
+            if (isRepeat && !subscription.repeat) {
+                return
+            }
+            if (!this.isWithinTarget(subscription.target, event)) {
+                return
+            }
+            if (subscription.callback(pressed, event) === true) {
+                handled = true
+            }
+        })
+
+        if (handled) {
+            event.preventDefault()
+        }
+    }
+
+    private isWithinTarget(target: HTMLElement | undefined, event: Event): boolean {
+        if (!target) {
+            return true
+        }
+        if (event.target instanceof Node && target.contains(event.target)) {
+            return true
+        }
+        return document.activeElement !== null && target.contains(document.activeElement)
+    }
+
+    private onPointerDown = (event: PointerEvent) => {
+        this._pointerDownCallbacks.forEach((callback) => callback(event))
+    }
+
+    subscribeToPointerDown(callback: (event: PointerEvent) => void): () => void {
+        this._pointerDownCallbacks.add(callback)
+        return () => this._pointerDownCallbacks.delete(callback)
     }
 
     subscribeToClick(callback: (event: MouseEvent) => void): () => void {
-        this._clickCallbacks.add(callback)
-        return () => this._clickCallbacks.delete(callback)
+        return this.subscribeToPointerDown(callback)
     }
 
-    subscribeToKey(key: string, callback: (pressed: boolean, event: KeyboardEvent) => void): () => void {
-        if (!this._keyCallbacks.has(key)) {
-            this._keyCallbacks.set(key, new Set())
+    subscribeToKey(key: string, callback: KeyEventCallback, options?: IKeySubscriptionOptions): () => void {
+        if (!this._keySubscriptions.has(key)) {
+            this._keySubscriptions.set(key, new Set())
         }
 
-        const callbacks = this._keyCallbacks.get(key)!
-        callbacks.add(callback)
+        const subscriptions = this._keySubscriptions.get(key)!
+        const subscription: IKeySubscription = {
+            callback,
+            target: options?.target,
+            repeat: options?.repeat ?? false,
+        }
+        subscriptions.add(subscription)
 
         return () => {
-            callbacks.delete(callback)
-            if (callbacks.size === 0) {
-                this._keyCallbacks.delete(key)
-                this._pressedKeys.delete(key)
+            subscriptions.delete(subscription)
+
+            /**
+             * CAUTION: Pressed state is deliberately kept when the last subscriber leaves.
+             * Deleting it would zero the recorded state of a key that is physically held,
+             * which corrupts modifier queries like isShiftPressed().
+             */
+            if (subscriptions.size === 0) {
+                this._keySubscriptions.delete(key)
             }
         }
+    }
+
+    beginDrag(event: PointerEvent, handlers: IDragHandlers): void {
+        if (this._activeDrag) {
+            this.finishDrag(event)
+        }
+
+        const pointerId = event.pointerId
+        const target = event.target instanceof Element ? event.target : null
+
+        try {
+            target?.setPointerCapture(pointerId)
+        } catch {
+            /**
+             * CAUTION: Capture can fail for detached elements or environments without
+             * pointer capture support; the drag still works via the document listeners.
+             */
+        }
+
+        const onMove = (moveEvent: PointerEvent) => {
+            if (moveEvent.pointerId === pointerId) {
+                handlers.onMove(moveEvent)
+            }
+        }
+        const onFinish = (finishEvent: PointerEvent) => {
+            if (finishEvent.pointerId === pointerId) {
+                this.finishDrag(finishEvent)
+            }
+        }
+
+        document.addEventListener('pointermove', onMove)
+        document.addEventListener('pointerup', onFinish)
+        document.addEventListener('pointercancel', onFinish)
+
+        this._activeDrag = { pointerId, target, onMove, onFinish, onEnd: handlers.onEnd }
+    }
+
+    private finishDrag(event: PointerEvent): void {
+        const drag = this._activeDrag
+        if (!drag) {
+            return
+        }
+
+        this._activeDrag = null
+        document.removeEventListener('pointermove', drag.onMove)
+        document.removeEventListener('pointerup', drag.onFinish)
+        document.removeEventListener('pointercancel', drag.onFinish)
+
+        try {
+            drag.target?.releasePointerCapture(drag.pointerId)
+        } catch {
+            /**
+             * CAUTION: Release fails when capture was never established; nothing to undo.
+             */
+        }
+
+        drag.onEnd?.(event)
     }
 
     isKeyPressed(key: string): boolean {
@@ -89,6 +208,6 @@ class GlobalEventManagerImpl implements IGlobalEventManager {
 
 /**
  * Allows registering event handlers for global window and DOM events, such as
- * mouse clicks and key presses.
+ * pointer presses and key presses.
  */
 export const GlobalEventManager = GlobalEventManagerImpl.getInstance()

--- a/src/event/event.types.ts
+++ b/src/event/event.types.ts
@@ -1,18 +1,75 @@
 /**
+ * A callback executed when a subscribed key transitions or repeats. Returning `true`
+ * marks the event as handled, causing the manager to call `preventDefault()` on it;
+ * any other return value leaves the browser's default behavior intact.
+ */
+export type KeyEventCallback = (pressed: boolean, event: KeyboardEvent) => boolean | void
+
+/**
+ * Describes the options by which a key subscription can be configured.
+ */
+export interface IKeySubscriptionOptions {
+    /**
+     * Restricts the subscription to key events originating inside this element
+     * (or while focus is inside it). Without a target, the subscription is global.
+     */
+    target?: HTMLElement
+
+    /**
+     * Whether the callback should fire repeatedly while the key is held. Defaults
+     * to false, firing only on the initial press and the release.
+     */
+    repeat?: boolean
+}
+
+/**
+ * Describes the handlers invoked over the lifetime of a pointer drag gesture
+ * hosted by the event manager.
+ */
+export interface IDragHandlers {
+    /**
+     * Invoked for every movement of the dragging pointer.
+     */
+    onMove: (event: PointerEvent) => void
+
+    /**
+     * Invoked once when the gesture ends, whether by release or cancellation.
+     */
+    onEnd?: (event: PointerEvent) => void
+}
+
+/**
  * Describes an object that manages event handlers and state
  * for global window and DOM events.
  */
 export interface IGlobalEventManager {
     /**
+     * Subscribes to a global pointer-down event, executing the callback provided when
+     * any pointer (mouse, touch, or pen) is pressed.
+     */
+    subscribeToPointerDown(callback: (event: PointerEvent) => void): () => void
+
+    /**
      * Subscribes to a global click event, executing the callback provided when the mouse is clicked.
+     *
+     * @deprecated Use {@link subscribeToPointerDown} instead, which also covers touch and pen input.
      */
     subscribeToClick(callback: (event: MouseEvent) => void): () => void
 
     /**
      * Subscribes to a global key event, executing the callback provided when the key is both pressed (key down)
-     * and released (key up).
+     * and released (key up). Options allow scoping the subscription to an element and opting into
+     * auto-repeat while the key is held.
      */
-    subscribeToKey(key: string, callback: (pressed: boolean, event: KeyboardEvent) => void): () => void
+    subscribeToKey(key: string, callback: KeyEventCallback, options?: IKeySubscriptionOptions): () => void
+
+    /**
+     * Hosts a pointer drag gesture, attaching one shared set of move / up / cancel listeners
+     * for the duration of the gesture and removing them when it ends. Pointer capture is
+     * managed centrally on the event's target. Only one drag is ever active; starting a new
+     * drag ends the previous one.
+     */
+    beginDrag(event: PointerEvent, handlers: IDragHandlers): void
 
     /**
      * Checks whether a given key is pressed.

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,3 +1,4 @@
 export * from './math.constants'
 export * from './math.types'
 export * from './math.utils'
+export * from './scale'

--- a/src/math/math.utils.test.ts
+++ b/src/math/math.utils.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import {
+    bestRationalApproximation,
+    calculateStartAngle,
+    calculateTotalAngle,
+    clamp,
+    createArcPath,
+    decibelsToGain,
+    findGreatestCommonDivisor,
+    gainToDecibels,
+    polarToCartesian,
+    round,
+    valueToAngle,
+} from './math.utils'
+
+describe('clamp', () => {
+    it('defaults to the [0, 1] range', () => {
+        expect(clamp(5)).toBe(1)
+        expect(clamp(-1)).toBe(0)
+        expect(clamp(0.5)).toBe(0.5)
+    })
+
+    it('respects explicit bounds', () => {
+        expect(clamp(5, 0, 10)).toBe(5)
+        expect(clamp(-5, -10, -1)).toBe(-5)
+        expect(clamp(15, 0, 10)).toBe(10)
+    })
+})
+
+describe('round', () => {
+    it('rounds to the requested number of fraction digits', () => {
+        expect(round(3.14159, 2)).toBe(3.14)
+        expect(round(2.71828, 3)).toBe(2.718)
+        expect(round(5, 0)).toBe(5)
+        expect(round(1.999, 2)).toBe(2)
+    })
+})
+
+describe('gainToDecibels', () => {
+    it('converts unity gain to 0 dB and half gain to about -6 dB', () => {
+        expect(gainToDecibels(1)).toBe(0)
+        expect(gainToDecibels(0.5)).toBeCloseTo(-6.0206, 4)
+    })
+
+    /**
+     * These two behaviors are pinned deliberately: over-unity gain is rejected as NaN
+     * rather than mapped to positive dB, and silence maps to -Infinity. Consumers that
+     * feed meters MUST clamp their gain into [0, 1] first or displays will blank out.
+     */
+    it('returns NaN outside [0, 1] and -Infinity at zero', () => {
+        expect(gainToDecibels(1.5)).toBeNaN()
+        expect(gainToDecibels(-0.1)).toBeNaN()
+        expect(gainToDecibels(0)).toBe(-Infinity)
+    })
+})
+
+describe('decibelsToGain', () => {
+    it('converts decibels back to linear gain', () => {
+        expect(decibelsToGain(0)).toBe(1)
+        expect(decibelsToGain(-6.0206)).toBeCloseTo(0.5, 4)
+    })
+
+    it('treats -100 dB and below as silence', () => {
+        expect(decibelsToGain(-100)).toBe(0)
+        expect(decibelsToGain(-200)).toBe(0)
+    })
+
+    it('round-trips with gainToDecibels inside the audible range', () => {
+        for (const db of [-60, -40, -20, -12, -6, -3, 0]) {
+            expect(gainToDecibels(decibelsToGain(db))).toBeCloseTo(db, 6)
+        }
+    })
+
+    it('rejects non-numeric input', () => {
+        expect(decibelsToGain(Number.NaN)).toBeNaN()
+    })
+})
+
+describe('polarToCartesian', () => {
+    it('measures angles from 12 o-clock', () => {
+        const [topX, topY] = polarToCartesian(50, 50, 40, 0)
+        expect(topX).toBeCloseTo(50, 9)
+        expect(topY).toBeCloseTo(10, 9)
+
+        const [rightX, rightY] = polarToCartesian(50, 50, 40, 90)
+        expect(rightX).toBeCloseTo(90, 9)
+        expect(rightY).toBeCloseTo(50, 9)
+    })
+})
+
+describe('valueToAngle', () => {
+    it('sweeps a unipolar value from the start angle across the total angle', () => {
+        const startOfTravel = calculateStartAngle() + 90
+        expect(valueToAngle(0, 0, 10, 'unipolar')).toBeCloseTo(startOfTravel, 9)
+        expect(valueToAngle(10, 0, 10, 'unipolar')).toBeCloseTo(startOfTravel + calculateTotalAngle(), 9)
+        expect(valueToAngle(5, 0, 10, 'unipolar')).toBeCloseTo(startOfTravel + calculateTotalAngle() / 2, 9)
+    })
+
+    it('centers a bipolar value on zero degrees', () => {
+        expect(valueToAngle(0, -10, 10, 'bipolar')).toBeCloseTo(0, 9)
+        expect(valueToAngle(10, -10, 10, 'bipolar')).toBeCloseTo(calculateTotalAngle() / 2, 9)
+        expect(valueToAngle(-10, -10, 10, 'bipolar')).toBeCloseTo(-calculateTotalAngle() / 2, 9)
+    })
+})
+
+describe('createArcPath', () => {
+    it('builds a closed wedge path around the center', () => {
+        const path = createArcPath(50, 50, 40, 0, 90)
+        expect(path.startsWith('M 50 50 L')).toBe(true)
+        expect(path).toContain('A 40 40')
+        expect(path.endsWith('Z')).toBe(true)
+    })
+
+    it('sets the large-arc flag only for sweeps beyond 180 degrees', () => {
+        expect(createArcPath(0, 0, 10, 0, 90)).toContain('A 10 10 0 0 0')
+        expect(createArcPath(0, 0, 10, 0, 270)).toContain('A 10 10 0 1 0')
+    })
+})
+
+describe('findGreatestCommonDivisor', () => {
+    it('finds the greatest common divisor', () => {
+        expect(findGreatestCommonDivisor(12, 18)).toBe(6)
+        expect(findGreatestCommonDivisor(7, 13)).toBe(1)
+        expect(findGreatestCommonDivisor(0, 5)).toBe(5)
+        expect(findGreatestCommonDivisor(-12, 18)).toBe(6)
+    })
+})
+
+describe('bestRationalApproximation', () => {
+    it('finds exact fractions for simple decimals', () => {
+        expect(bestRationalApproximation(0.5, 1e-6, 100)).toEqual([1, 2])
+        expect(bestRationalApproximation(0.75, 1e-6, 100)).toEqual([3, 4])
+        expect(bestRationalApproximation(0.3333333, 1e-6, 100)).toEqual([1, 3])
+    })
+
+    it('returns whole numbers over one', () => {
+        expect(bestRationalApproximation(3, 1e-6, 100)).toEqual([3, 1])
+    })
+})

--- a/src/math/scale.test.ts
+++ b/src/math/scale.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Scale } from './math.types'
+import { applyScale, unapplyScale } from './scale'
+
+const MIN_HZ = 20
+const MAX_HZ = 20_000
+
+const ALL_SCALES: (Scale | undefined)[] = ['linear', 'quadratic', 'cubic', 'logarithmic', 'exponential', undefined]
+
+describe('applyScale', () => {
+    it('maps the logarithmic curve over 20 Hz - 20 kHz to the geometric oracle values', () => {
+        expect(applyScale(0, 'logarithmic', MIN_HZ, MAX_HZ)).toBeCloseTo(20, 9)
+        expect(applyScale(0.25, 'logarithmic', MIN_HZ, MAX_HZ)).toBeCloseTo(112.46826503807, 6)
+        expect(applyScale(0.5, 'logarithmic', MIN_HZ, MAX_HZ)).toBeCloseTo(632.45553203368, 6)
+        expect(applyScale(1, 'logarithmic', MIN_HZ, MAX_HZ)).toBeCloseTo(20_000, 6)
+    })
+
+    it('is continuous approaching zero, unlike the old fixed 100:1 curve', () => {
+        const nearZero = applyScale(1e-9, 'logarithmic', MIN_HZ, MAX_HZ)
+        expect(nearZero).toBeGreaterThan(MIN_HZ)
+        expect(nearZero).toBeLessThan(MIN_HZ + 0.001)
+    })
+
+    it('treats exponential as an alias of logarithmic', () => {
+        for (let i = 0; i <= 16; i++) {
+            const n = i / 16
+            expect(applyScale(n, 'exponential', MIN_HZ, MAX_HZ)).toBe(applyScale(n, 'logarithmic', MIN_HZ, MAX_HZ))
+        }
+    })
+
+    it('applies true power curves for quadratic and cubic instead of falling back to linear', () => {
+        expect(applyScale(0.5, 'quadratic', 0, 100)).toBeCloseTo(25, 9)
+        expect(applyScale(0.5, 'cubic', 0, 100)).toBeCloseTo(12.5, 9)
+        expect(applyScale(0.5, 'linear', 0, 100)).toBeCloseTo(50, 9)
+    })
+
+    it('defaults to linear when no scale is given', () => {
+        expect(applyScale(0.3, undefined, 0, 10)).toBeCloseTo(3, 9)
+    })
+
+    it('clamps the normalized input into [0, 1]', () => {
+        expect(applyScale(-0.5, 'linear', 0, 10)).toBe(0)
+        expect(applyScale(1.5, 'linear', 0, 10)).toBe(10)
+    })
+
+    it('collapses a degenerate range to its minimum', () => {
+        expect(applyScale(0.7, 'linear', 5, 5)).toBe(5)
+        expect(applyScale(0.7, 'logarithmic', 5, 5)).toBe(5)
+    })
+
+    it('falls back to linear with a warning when logarithmic is configured with min <= 0', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        expect(applyScale(0.5, 'logarithmic', 0, 100)).toBeCloseTo(50, 9)
+        expect(unapplyScale(50, 'logarithmic', 0, 100)).toBeCloseTo(0.5, 9)
+        expect(applyScale(0.5, 'logarithmic', -10, 100)).toBeCloseTo(45, 9)
+
+        expect(warn).toHaveBeenCalled()
+        warn.mockRestore()
+    })
+})
+
+describe('unapplyScale', () => {
+    it('round-trips applyScale across the full normalized range for every scale', () => {
+        for (const scale of ALL_SCALES) {
+            for (let i = 0; i <= 32; i++) {
+                const n = i / 32
+                const display = applyScale(n, scale, MIN_HZ, MAX_HZ)
+                expect(unapplyScale(display, scale, MIN_HZ, MAX_HZ)).toBeCloseTo(n, 9)
+            }
+        }
+    })
+
+    it('inverts the logarithmic oracle values', () => {
+        expect(unapplyScale(112.46826503807, 'logarithmic', MIN_HZ, MAX_HZ)).toBeCloseTo(0.25, 9)
+        expect(unapplyScale(632.45553203368, 'logarithmic', MIN_HZ, MAX_HZ)).toBeCloseTo(0.5, 9)
+    })
+
+    it('clamps display values outside [min, max] into range', () => {
+        expect(unapplyScale(5, 'logarithmic', MIN_HZ, MAX_HZ)).toBe(0)
+        expect(unapplyScale(30_000, 'logarithmic', MIN_HZ, MAX_HZ)).toBe(1)
+        expect(unapplyScale(-3, 'linear', 0, 10)).toBe(0)
+        expect(unapplyScale(13, 'linear', 0, 10)).toBe(1)
+    })
+
+    it('returns zero for a degenerate range', () => {
+        expect(unapplyScale(5, 'linear', 5, 5)).toBe(0)
+    })
+})

--- a/src/math/scale.ts
+++ b/src/math/scale.ts
@@ -1,0 +1,84 @@
+import type { Scale } from './math.types'
+import { clamp } from './math.utils'
+
+let hasWarnedNonPositiveMin = false
+
+function isLogarithmicRangeValid(min: number): boolean {
+    if (min > 0) {
+        return true
+    }
+
+    /**
+     * CAUTION: A ratio curve cannot represent a range that touches or crosses zero,
+     * and silently returning NaN / -Infinity would be worse than a loud fallback,
+     * so we warn once and treat the range as linear.
+     */
+    if (!hasWarnedNonPositiveMin) {
+        hasWarnedNonPositiveMin = true
+        console.warn(
+            `The 'logarithmic' scale requires a minimum greater than zero (received ${min}). Falling back to 'linear'.`
+        )
+    }
+
+    return false
+}
+
+/**
+ * Maps a normalized value in [0, 1] to a display value in [min, max] according to
+ * the given scale.
+ *
+ * - `linear` — straight interpolation between min and max.
+ * - `quadratic` — power curve (n^2), biasing travel toward the low end of the range.
+ * - `cubic` — power curve (n^3), a stronger low-end bias than `quadratic`.
+ * - `logarithmic` — ratio curve `min * (max / min)^n`, giving equal travel per octave
+ *   or decade. Requires `min > 0`; otherwise falls back to `linear` with a warning.
+ * - `exponential` — deprecated alias of `logarithmic`.
+ */
+export function applyScale(normalizedValue: number, scale: Scale | undefined, min: number, max: number): number {
+    if (max <= min) {
+        return min
+    }
+
+    const n = clamp(normalizedValue)
+    switch (scale) {
+        case 'quadratic':
+            return min + n * n * (max - min)
+        case 'cubic':
+            return min + n * n * n * (max - min)
+        case 'exponential':
+        case 'logarithmic':
+            if (!isLogarithmicRangeValid(min)) {
+                return min + n * (max - min)
+            }
+            return min * Math.pow(max / min, n)
+        default:
+            return min + n * (max - min)
+    }
+}
+
+/**
+ * Maps a display value in [min, max] back to a normalized value in [0, 1], inverting
+ * the curve applied by {@link applyScale}. Display values outside [min, max] are
+ * clamped into range first.
+ */
+export function unapplyScale(displayValue: number, scale: Scale | undefined, min: number, max: number): number {
+    if (max <= min) {
+        return 0
+    }
+
+    const v = clamp(displayValue, min, max)
+    switch (scale) {
+        case 'quadratic':
+            return Math.sqrt((v - min) / (max - min))
+        case 'cubic':
+            return Math.cbrt((v - min) / (max - min))
+        case 'exponential':
+        case 'logarithmic':
+            if (!isLogarithmicRangeValid(min)) {
+                return (v - min) / (max - min)
+            }
+            return Math.log(v / min) / Math.log(max / min)
+        default:
+            return (v - min) / (max - min)
+    }
+}

--- a/src/parameter/index.ts
+++ b/src/parameter/index.ts
@@ -1,2 +1,3 @@
 export * from './parameter-manager.ts'
 export * from './parameter.types.ts'
+export * from './parameters'

--- a/src/parameter/parameter-manager.test.ts
+++ b/src/parameter/parameter-manager.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ParameterType, type IFloatParameterConfig } from './parameter.types.ts'
+
+/**
+ * Importing the manager pulls in the JUCE interop module, which warns while installing
+ * its placeholder when no native host is present; silence that for the test run.
+ */
+vi.spyOn(console, 'warn').mockImplementation(() => {})
+vi.spyOn(console, 'log').mockImplementation(() => {})
+
+const { ParameterManager } = await import('./parameter-manager.ts')
+
+const config: IFloatParameterConfig = {
+    id: 'hpf',
+    name: 'low cut',
+    type: ParameterType.Float,
+    min: 20,
+    max: 20_000,
+    defaultValue: 100,
+    scale: 'logarithmic',
+}
+
+describe('ParameterManager without a JUCE backend', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    /**
+     * Regression: the relay used to be wired unconditionally, and the placeholder
+     * slider state clobbered every default value to normalized zero (display min).
+     */
+    it('preserves the configured default under auto detection', () => {
+        const manager = new ParameterManager()
+        const parameter = manager.registerParameter(config)
+        expect(parameter.displayValue).toBeCloseTo(100, 6)
+    })
+
+    it('preserves the configured default when the backend is explicitly disabled', () => {
+        const manager = new ParameterManager({ backend: 'none' })
+        const parameter = manager.registerParameter(config)
+        expect(parameter.displayValue).toBeCloseTo(100, 6)
+    })
+
+    it('rejects initializeParameters instead of hanging forever', async () => {
+        const manager = new ParameterManager({ backend: 'none' })
+        await expect(manager.initializeParameters()).rejects.toThrow('JUCE backend')
+    })
+
+    it('registers, finds, and removes parameters', () => {
+        const manager = new ParameterManager({ backend: 'none' })
+        manager.registerParameter(config)
+
+        expect(manager.hasParameter('hpf')).toBe(true)
+        expect(manager.getParameter('hpf')).toBeDefined()
+
+        manager.removeParameter('hpf')
+        expect(manager.hasParameter('hpf')).toBe(false)
+    })
+
+    it('resets all parameters to their defaults', () => {
+        const manager = new ParameterManager({ backend: 'none' })
+        const parameter = manager.registerParameter(config)
+
+        parameter.setNormalizedValue(1, false)
+        manager.resetParameters()
+
+        expect(parameter.displayValue).toBeCloseTo(100, 6)
+    })
+})

--- a/src/parameter/parameter-manager.ts
+++ b/src/parameter/parameter-manager.ts
@@ -1,10 +1,11 @@
-import { getComboBoxState, getSliderState, getToggleState, NativeFunctionAdapter } from '$lib/juce'
+import { getComboBoxState, getSliderState, getToggleState, type IJuceGlobal, NativeFunctionAdapter } from '$lib/juce'
 import { BooleanParameter, ChoiceParameter, FloatParameter } from './parameters'
 import {
     type IBooleanParameterConfig,
     type IChoiceParameterConfig,
     type IFloatParameterConfig,
     type IParameterManager,
+    type IParameterManagerOptions,
     type Parameter,
     ParameterChangeSource,
     type ParameterConfig,
@@ -21,8 +22,35 @@ import {
 export class ParameterManager implements IParameterManager {
     private _parameters: Record<string, Parameter> = {}
     private _backendCleanups = new Map<string, () => void>()
+    private readonly _backendEnabled: boolean
+
+    constructor(options?: IParameterManagerOptions) {
+        const backend = options?.backend ?? 'auto'
+        this._backendEnabled = backend === 'juce' || (backend === 'auto' && ParameterManager.isJuceBackendPresent())
+    }
+
+    /**
+     * Distinguishes a real JUCE WebView host from the placeholder interop object that
+     * gets installed when no native backend exists. A genuine host always reports its
+     * platform in the initialisation data, whereas the placeholder leaves it empty.
+     */
+    private static isJuceBackendPresent(): boolean {
+        if (typeof window === 'undefined') {
+            return false
+        }
+
+        const juce = window.__JUCE__ as IJuceGlobal | undefined
+        return (juce?.initialisationData?.__juce__platform?.length ?? 0) > 0
+    }
 
     async initializeParameters(): Promise<void> {
+        if (!this._backendEnabled) {
+            throw new Error(
+                'ParameterManager.initializeParameters() requires a JUCE backend, which is not available. ' +
+                    'Register parameters directly with registerParameter() instead.'
+            )
+        }
+
         const jsonString = await NativeFunctionAdapter.getParametersJsonData()
         const { parameters } = JSON.parse(jsonString) as { parameters: ParameterConfig[] }
         for (const config of parameters) {
@@ -33,7 +61,9 @@ export class ParameterManager implements IParameterManager {
     registerParameter<T extends ParameterType>(config: ParameterConfigFromType<T>): ParameterFromType<T> {
         const parameter = this.createParameter<T>(config)
         this._parameters[config.id] = parameter
-        this.setupBackendRelay(parameter)
+        if (this._backendEnabled) {
+            this.setupBackendRelay(parameter)
+        }
         return parameter
     }
 

--- a/src/parameter/parameter.types.ts
+++ b/src/parameter/parameter.types.ts
@@ -318,6 +318,37 @@ export type ParameterValueFromType<T extends ParameterType> = T extends Paramete
         : never
 
 /**
+ * The strategy a parameter manager uses for connecting parameters to a native backend.
+ */
+export type ParameterBackend =
+    /**
+     * Detects whether a real JUCE WebView host is present and relays to it only
+     * when it is. This is the default.
+     */
+    | 'auto'
+
+    /**
+     * Always relays to the JUCE backend, regardless of detection.
+     */
+    | 'juce'
+
+    /**
+     * Never relays to a backend; parameters are purely frontend objects. Use this
+     * for standalone web applications with no native host.
+     */
+    | 'none'
+
+/**
+ * Describes the options by which a parameter manager can be configured.
+ */
+export interface IParameterManagerOptions {
+    /**
+     * The backend connection strategy to use. Defaults to 'auto'.
+     */
+    backend?: ParameterBackend
+}
+
+/**
  * Describes functionality to manage our parameters in various aspects, including
  * initialization, cleanup, and simple getter methods.
  */

--- a/src/parameter/parameters/boolean.parameter.test.ts
+++ b/src/parameter/parameters/boolean.parameter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ParameterChangeSource, ParameterType, type IBooleanParameterConfig } from '../parameter.types.ts'
+import { BooleanParameter } from './boolean.parameter.ts'
+
+const config: IBooleanParameterConfig = {
+    id: 'bypass',
+    name: 'bypass',
+    type: ParameterType.Boolean,
+    defaultValue: true,
+}
+
+describe('BooleanParameter', () => {
+    it('honours the configured default value on construction', () => {
+        expect(new BooleanParameter(config).getValue()).toBe(true)
+    })
+
+    it('toggles and notifies listeners', () => {
+        const parameter = new BooleanParameter(config)
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.toggle(ParameterChangeSource.Internal)
+
+        expect(parameter.getValue()).toBe(false)
+        expect(listener).toHaveBeenCalledWith(false, ParameterChangeSource.Internal)
+    })
+
+    it('skips notifications when the value does not change', () => {
+        const parameter = new BooleanParameter(config)
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.setValue(true)
+
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('resets to the default value', () => {
+        const parameter = new BooleanParameter(config)
+        parameter.setValue(false)
+        parameter.resetValue()
+        expect(parameter.getValue()).toBe(true)
+    })
+})

--- a/src/parameter/parameters/choice.parameter.test.ts
+++ b/src/parameter/parameters/choice.parameter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ParameterType, type IChoiceParameterConfig } from '../parameter.types.ts'
+import { ChoiceParameter } from './choice.parameter.ts'
+
+const config: IChoiceParameterConfig = {
+    id: 'noiseType',
+    name: 'noise type',
+    type: ParameterType.Choice,
+    choices: ['white', 'pink', 'brown'],
+    defaultValueIndex: 1,
+}
+
+describe('ChoiceParameter', () => {
+    it('honours the configured default index on construction', () => {
+        expect(new ChoiceParameter(config).getValue()).toBe(1)
+    })
+
+    it('clamps the default index into the range of choices', () => {
+        expect(new ChoiceParameter({ ...config, defaultValueIndex: 9 }).getValue()).toBe(2)
+        expect(new ChoiceParameter({ ...config, defaultValueIndex: -3 }).getValue()).toBe(0)
+    })
+
+    it('clamps set values into the range of choices', () => {
+        const parameter = new ChoiceParameter(config)
+        parameter.setValue(5)
+        expect(parameter.getValue()).toBe(2)
+        parameter.setValue(-1)
+        expect(parameter.getValue()).toBe(0)
+    })
+
+    it('sets the choice by value and notifies', () => {
+        const parameter = new ChoiceParameter(config)
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.setChoiceByValue('brown')
+
+        expect(parameter.getValue()).toBe(2)
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores unknown values in setChoiceByValue', () => {
+        const parameter = new ChoiceParameter(config)
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.setChoiceByValue('violet')
+
+        expect(parameter.getValue()).toBe(1)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('resets to the default index', () => {
+        const parameter = new ChoiceParameter(config)
+        parameter.setValue(2)
+        parameter.resetValue()
+        expect(parameter.getValue()).toBe(1)
+    })
+})

--- a/src/parameter/parameters/float.parameter.test.ts
+++ b/src/parameter/parameters/float.parameter.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ParameterChangeSource, ParameterType, type IFloatParameterConfig } from '../parameter.types.ts'
+import { FloatParameter } from './float.parameter.ts'
+
+function createLogFrequencyConfig(overrides: Partial<IFloatParameterConfig> = {}): IFloatParameterConfig {
+    return {
+        id: 'hpf',
+        name: 'low cut',
+        type: ParameterType.Float,
+        min: 20,
+        max: 20_000,
+        defaultValue: 100,
+        scale: 'logarithmic',
+        unit: 'Hz',
+        ...overrides,
+    }
+}
+
+describe('FloatParameter', () => {
+    it('honours the configured default value on construction', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        expect(parameter.displayValue).toBeCloseTo(100, 6)
+        expect(parameter.normalizedValue).toBeCloseTo(0.2329902, 6)
+    })
+
+    /**
+     * Regression: the old fixed 100:1 logarithmic curve produced a NEGATIVE normalized
+     * value (about -0.198) for a 100 Hz default on a 20 Hz - 20 kHz range, which then
+     * leaked out of range through normalizedValue and normalizedDefaultValue.
+     */
+    it('keeps the constructed and default normalized values inside [0, 1]', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        expect(parameter.normalizedValue).toBeGreaterThanOrEqual(0)
+        expect(parameter.normalizedValue).toBeLessThanOrEqual(1)
+        expect(parameter.normalizedDefaultValue).toBeGreaterThanOrEqual(0)
+        expect(parameter.normalizedDefaultValue).toBeLessThanOrEqual(1)
+        expect(parameter.normalizedDefaultValue).toBeCloseTo(parameter.normalizedValue, 9)
+    })
+
+    it('clamps setNormalizedValue into [0, 1]', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        parameter.setNormalizedValue(1.5, false)
+        expect(parameter.normalizedValue).toBe(1)
+        parameter.setNormalizedValue(-0.2, false)
+        expect(parameter.normalizedValue).toBe(0)
+    })
+
+    it('skips notifications when the value does not change', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.setNormalizedValue(0.5, true)
+        parameter.setNormalizedValue(0.5, true)
+
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    /**
+     * Regression: setDisplayValue used to write the normalized value directly without
+     * notifying listeners, silently desyncing subscribers, and without clamping.
+     */
+    it('notifies listeners from setDisplayValue with the given source', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.setDisplayValue(1000, ParameterChangeSource.Internal)
+
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(listener.mock.calls[0][0]).toBeCloseTo(0.56632333, 6)
+        expect(listener.mock.calls[0][1]).toBe(ParameterChangeSource.Internal)
+        expect(parameter.displayValue).toBeCloseTo(1000, 6)
+    })
+
+    it('defaults setDisplayValue to the frontend source and clamps out-of-range values', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+
+        parameter.setDisplayValue(30_000)
+
+        expect(parameter.normalizedValue).toBe(1)
+        expect(listener.mock.calls[0][1]).toBe(ParameterChangeSource.Frontend)
+    })
+
+    it('resets to the default value and notifies', () => {
+        const parameter = new FloatParameter(createLogFrequencyConfig())
+        parameter.setNormalizedValue(0.9, false)
+
+        const listener = vi.fn()
+        parameter.subscribe(listener)
+        parameter.resetValue()
+
+        expect(parameter.displayValue).toBeCloseTo(100, 6)
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('snaps display values to the configured interval', () => {
+        const parameter = new FloatParameter({
+            id: 'amount',
+            name: 'amount',
+            type: ParameterType.Float,
+            min: 0,
+            max: 100,
+            defaultValue: 0,
+            interval: 5,
+        })
+
+        expect(parameter.normalizedToDisplay(0.501)).toBe(50)
+        expect(parameter.normalizedToDisplay(0.529)).toBe(55)
+    })
+
+    describe('midpoint skew', () => {
+        const config: IFloatParameterConfig = {
+            id: 'gain',
+            name: 'gain',
+            type: ParameterType.Float,
+            min: 0,
+            max: 10,
+            defaultValue: 0,
+            midpoint: 2.5,
+        }
+
+        it('places the midpoint value at half travel', () => {
+            const parameter = new FloatParameter(config)
+            expect(parameter.normalizedToDisplay(0.5)).toBeCloseTo(2.5, 9)
+            expect(parameter.displayToNormalized(2.5)).toBeCloseTo(0.5, 9)
+        })
+
+        it('takes precedence over a configured scale', () => {
+            const parameter = new FloatParameter({ ...config, scale: 'quadratic' })
+            expect(parameter.normalizedToDisplay(0.5)).toBeCloseTo(2.5, 9)
+        })
+
+        it('converts display values to the skewed JUCE normalized domain', () => {
+            const parameter = new FloatParameter(config)
+            expect(parameter.displayToJuceNormalized(2.5)).toBeCloseTo(0.5, 9)
+        })
+
+        /**
+         * Regression: displayToJuceNormalized duplicated the skew math without the
+         * guard, so a midpoint equal to min produced an infinite skew and the method
+         * returned 1 for every input.
+         */
+        it('guards degenerate midpoints instead of collapsing to a constant', () => {
+            const atMin = new FloatParameter({ ...config, midpoint: 0 })
+            expect(atMin.displayToJuceNormalized(5)).toBeCloseTo(0.5, 9)
+
+            const atMax = new FloatParameter({ ...config, midpoint: 10 })
+            expect(atMax.displayToJuceNormalized(5)).toBeCloseTo(0.5, 9)
+        })
+    })
+})

--- a/src/parameter/parameters/float.parameter.ts
+++ b/src/parameter/parameters/float.parameter.ts
@@ -1,4 +1,4 @@
-import type { Scale } from '$lib/math'
+import { applyScale, clamp, unapplyScale } from '$lib/math'
 import { ParameterChangeSource, type IFloatParameterConfig, ParameterType } from '../parameter.types.ts'
 import { BaseParameter } from './base.parameter.ts'
 
@@ -12,7 +12,7 @@ export class FloatParameter extends BaseParameter<ParameterType.Float> {
 
     constructor(config: IFloatParameterConfig) {
         super(config)
-        this._normalizedValue = this.displayToNormalized(config.defaultValue)
+        this._normalizedValue = clamp(this.displayToNormalized(config.defaultValue))
     }
 
     // Fields & attributes
@@ -35,7 +35,7 @@ export class FloatParameter extends BaseParameter<ParameterType.Float> {
 
     get normalizedDefaultValue() {
         const { defaultValue } = this.config as IFloatParameterConfig
-        return this.displayToNormalized(defaultValue)
+        return clamp(this.displayToNormalized(defaultValue))
     }
 
     setNormalizedValue(
@@ -43,7 +43,7 @@ export class FloatParameter extends BaseParameter<ParameterType.Float> {
         shouldNotify: boolean,
         source: ParameterChangeSource = ParameterChangeSource.Frontend
     ): void {
-        const clamped = Math.max(0, Math.min(1, value))
+        const clamped = clamp(value)
         if (this._normalizedValue !== clamped) {
             this._normalizedValue = clamped
             if (shouldNotify) {
@@ -56,20 +56,18 @@ export class FloatParameter extends BaseParameter<ParameterType.Float> {
         return this.normalizedToDisplay(this._normalizedValue)
     }
 
-    setDisplayValue(value: number) {
-        this._normalizedValue = this.displayToNormalized(value)
+    setDisplayValue(value: number, source: ParameterChangeSource = ParameterChangeSource.Frontend): void {
+        this.setNormalizedValue(this.displayToNormalized(value), true, source)
     }
 
     // Mathematics
 
     displayToJuceNormalized(displayValue: number): number {
         const config = this.config as IFloatParameterConfig
-        const range = config.max - config.min
-        const linear = (displayValue - config.min) / range
+        const linear = (displayValue - config.min) / (config.max - config.min)
 
         if (config.midpoint !== undefined) {
-            const normalizedMidpoint = (config.midpoint - config.min) / range
-            const skew = Math.log(normalizedMidpoint) / Math.log(0.5)
+            const skew = this.calculateSkewFactor(config.midpoint)
             if (skew === 1) {
                 return linear
             } else {
@@ -82,15 +80,26 @@ export class FloatParameter extends BaseParameter<ParameterType.Float> {
 
     displayToNormalized(displayValue: number): number {
         const config = this.config as IFloatParameterConfig
-        const clamped = Math.max(config.min, Math.min(config.max, displayValue))
-        const linear = (clamped - config.min) / (config.max - config.min)
-        return this.unapplyScale(linear, config.scale, config.midpoint)
+
+        if (config.midpoint !== undefined) {
+            const clamped = clamp(displayValue, config.min, config.max)
+            const linear = (clamped - config.min) / (config.max - config.min)
+            return this.unapplySkew(linear, config.midpoint)
+        }
+
+        return unapplyScale(displayValue, config.scale, config.min, config.max)
     }
 
     normalizedToDisplay(normalizedValue: number): number {
         const config = this.config as IFloatParameterConfig
-        const scaled = this.applyScale(normalizedValue, config.scale, config.midpoint)
-        let value = config.min + scaled * (config.max - config.min)
+
+        let value: number
+        if (config.midpoint !== undefined) {
+            const skewed = this.applySkew(clamp(normalizedValue), config.midpoint)
+            value = config.min + skewed * (config.max - config.min)
+        } else {
+            value = applyScale(normalizedValue, config.scale, config.min, config.max)
+        }
 
         if (config.interval) {
             value = this.snapToInterval(value)
@@ -114,44 +123,14 @@ export class FloatParameter extends BaseParameter<ParameterType.Float> {
         }
     }
 
-    private applyScale(normalizedValue: number, scale?: Scale, midpoint?: number): number {
-        if (midpoint !== undefined) {
-            const skew = this.calculateSkewFactor(midpoint)
-            if (skew === 1) {
-                return normalizedValue
-            } else {
-                return Math.pow(normalizedValue, skew)
-            }
-        } else {
-            switch (scale) {
-                case 'exponential':
-                    return normalizedValue * normalizedValue
-                case 'logarithmic':
-                    return normalizedValue === 0 ? 0 : Math.pow(10, normalizedValue * 2 - 2)
-                default:
-                    return normalizedValue
-            }
-        }
+    private applySkew(normalizedValue: number, midpoint: number): number {
+        const skew = this.calculateSkewFactor(midpoint)
+        return skew === 1 ? normalizedValue : Math.pow(normalizedValue, skew)
     }
 
-    private unapplyScale(scaled: number, scale?: Scale, midpoint?: number): number {
-        if (midpoint !== undefined) {
-            const skew = this.calculateSkewFactor(midpoint)
-            if (skew === 1) {
-                return scaled
-            } else {
-                return Math.pow(scaled, 1 / skew)
-            }
-        } else {
-            switch (scale) {
-                case 'exponential':
-                    return Math.sqrt(scaled)
-                case 'logarithmic':
-                    return scaled === 0 ? 0 : (Math.log10(scaled) + 2) / 2
-                default:
-                    return scaled
-            }
-        }
+    private unapplySkew(linear: number, midpoint: number): number {
+        const skew = this.calculateSkewFactor(midpoint)
+        return skew === 1 ? linear : Math.pow(linear, 1 / skew)
     }
 
     private snapToInterval(value: number): number {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,5 @@
         }
     },
     "include": ["src"],
-    "exclude": ["node_modules", "scripts"]
+    "exclude": ["node_modules", "scripts", "**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    plugins: [tsconfigPaths()],
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
@@ -26,6 +37,34 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
+
+"@csstools/color-helpers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
+  integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.4.tgz#8473f63e2fcd6e459838dd412401d5948f224c65"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz#4e386af3a99dd36c46fef013cfe4c1c341eed6f0"
+  integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
+  dependencies:
+    "@csstools/color-helpers" "^5.1.0"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
 "@esbuild/aix-ppc64@0.25.9":
   version "0.25.9"
@@ -819,6 +858,11 @@ acorn@^8.15.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
 ajv-draft-04@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz#3b64761b268ba0b9e668f0b41ba53fce0ad77fc8"
@@ -1054,10 +1098,33 @@ cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cssstyle@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
+
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
+
+debug@4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1:
   version "4.4.1"
@@ -1065,6 +1132,11 @@ debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
   dependencies:
     ms "^2.1.3"
+
+decimal.js@^10.5.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -1100,6 +1172,11 @@ entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 environment@^1.0.0:
   version "1.1.0"
@@ -1445,10 +1522,40 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 husky@8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -1519,6 +1626,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1552,6 +1664,32 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsdom@26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.1.0.tgz#ab5f1c1cafc04bd878725490974ea5e8bf0c72b3"
+  integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
+  dependencies:
+    cssstyle "^4.2.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.5.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.16"
+    parse5 "^7.2.1"
+    rrweb-cssom "^0.8.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.1.1"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.1.1"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -1684,6 +1822,11 @@ loupe@^3.1.0, loupe@^3.1.4:
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
   integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
 
+lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.1.0.tgz#afafb060607108132dbc1cf8ae661afb69486117"
@@ -1804,6 +1947,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+nwsapi@^2.2.16:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
+
 onetime@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
@@ -1848,6 +1996,13 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse5@^7.2.1:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
 
 path-browserify@^1.0.1:
   version "1.0.1"
@@ -1949,7 +2104,7 @@ punycode.js@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
   integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -2039,12 +2194,29 @@ rollup@^4.43.0:
     "@rollup/rollup-win32-x64-msvc" "4.50.1"
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 semver@^7.6.0:
   version "7.7.2"
@@ -2214,6 +2386,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -2247,12 +2424,38 @@ tinyspy@^4.0.3:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.3.tgz#d1d0f0602f4c15f1aae083a34d6d0df3363b1b52"
   integrity sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==
 
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tough-cookie@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
+  dependencies:
+    tldts "^6.1.32"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
 
 ts-api-utils@^2.1.0:
   version "2.1.0"
@@ -2429,6 +2632,38 @@ vscode-uri@^3.0.8:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0, whatwg-url@^14.1.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -2475,6 +2710,21 @@ wrap-ansi@^9.0.0:
     ansi-styles "^6.2.1"
     string-width "^7.0.0"
     strip-ansi "^7.1.0"
+
+ws@^8.18.0:
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
+  integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary

Makes nectar usable by standalone web apps (no JUCE backend), fixes the scale math, extends the event manager to pointer input, and adds the repo's first test suite. Version `0.3.0`.

### Scale math (`src/math/scale.ts`, new)

`applyScale`/`unapplyScale` are now pure, exported functions with corrected curves:

| Scale | Before | After |
|---|---|---|
| `logarithmic` | `10^(2n-2)` — a fixed 100:1 curve that ignored min/max and was discontinuous at n=0 (a 20 Hz–20 kHz parameter jumped 20 → ~220 Hz at the bottom of travel, and read 651.8 Hz at quarter travel where a log sweep reads 112.5 Hz) | `min * (max/min)^n` — true ratio curve; requires `min > 0`, else falls back to linear with a one-time warning |
| `quadratic` / `cubic` | silently linear | `n²` / `n³` |
| `exponential` | `n²` | deprecated alias of `logarithmic` (nothing anywhere set `scale:`, verified across every consumer repo) |

### Parameters without JUCE

- `FloatParameter`/`BooleanParameter`/`ChoiceParameter` are now exported — they were always backend-free; only `ParameterManager` coupled them to JUCE
- `new ParameterManager({ backend: 'auto' | 'juce' | 'none' })`, default `'auto'`, which detects a real JUCE host via the initialisation data platform. Without a host, the relay is skipped, so defaults are no longer clobbered to zero by the placeholder slider state, and `initializeParameters()` rejects fast instead of awaiting a native call that never resolves
- `setDisplayValue` now clamps, notifies listeners, and honours `source` (it previously did none of those, silently desyncing subscribers)
- Constructor and `normalizedDefaultValue` clamp into [0, 1] (a log-scale default near min used to produce a negative normalized value)
- `displayToJuceNormalized` gains the guard the other midpoint path already had (midpoint == min used to return 1 for every input; < min returned NaN — straight to JUCE)

### Event manager

- `pointerdown` replaces `mousedown` internally (covers mouse + touch + pen); `subscribeToClick` remains as a deprecated alias of `subscribeToPointerDown`
- `subscribeToKey(key, cb, { target?, repeat? })` — element scoping (one containment check per subscriber, still one document listener) and opt-in auto-repeat for held keys
- Handled-protocol: a callback returning `true` marks the event consumed and the manager calls `preventDefault()` — consumers no longer have to call it unconditionally
- Pressed state survives the last unsubscribe (previously a held modifier's state was zeroed)
- `beginDrag(event, { onMove, onEnd })` hosts one shared `pointermove`/`pointerup`/`pointercancel` set per gesture with central pointer capture — one drag ever active, so component libraries stop attaching their own document listeners per knob

### Tests (first in the repo — 67)

`vitest run`: scale round-trips across all curves plus the 20 Hz–20 kHz oracle table (20 / 112.47 / 632.46 / 20 000), math utils incl. deliberate pins of `gainToDecibels`' NaN-above-unity behavior, parameter regressions (default preservation, `setDisplayValue` notification, midpoint guards), and event manager lifecycle (exactly three document listeners regardless of subscription count, scoping, handled-protocol, repeat, drag listener removal on up *and* cancel).

### CI

`cd.publish-automatic.yml` now requires the triggering Build run to have **succeeded** — it previously fired on `completed`, so a failed build with a version bump still published to npm.

## Migration notes (template-plugin)

Nothing breaks at publish — template-plugin pins `0.2.0` exactly. When it bumps to `0.3.0`:
- `ParameterManager` behavior is unchanged inside a real JUCE WebView (`'auto'` detects the host); pass `{ backend: 'juce' }` to force the old unconditional wiring
- `subscribeToClick` still works (deprecated); switch to `subscribeToPointerDown` when convenient
- Key callbacks may now return `true` to consume events — existing void callbacks behave as before, but `preventDefault` is no longer called unless a callback opts in

## Testing

- `yarn test` — 67/67
- `yarn build` — clean; `dist/index.d.ts` verified to export the parameter classes, scale functions, and new event manager API
- `npx eslint` + `prettier --check` — clean
- Exercised end to end by the hush PWA (blackboxaudio/honey#pointer-input PR and the eden hush PR), including offline-rendered spectral verification through `FloatParameter`'s log scale
